### PR TITLE
Update raop_client.c

### DIFF
--- a/src/modules/raop/raop_client.c
+++ b/src/modules/raop/raop_client.c
@@ -1051,6 +1051,14 @@ pa_raop_client* pa_raop_client_new(pa_core *core, const char *host,
 
     if (pa_parse_address(host, &a) < 0 || a.type == PA_PARSED_ADDRESS_UNIX)
         return NULL;
+        
+    if(strstr(host,"::"))
+    {
+        pa_log_warn("Host: %s",host);
+        pa_log_warn("IPV6 is not supported!");
+        return NULL;
+    }
+
 
     c->core = core;
     c->tcp_fd = -1;


### PR DESCRIPTION
I get dual shairport hosts. One is IPV4 and the other one is IPV6. Whenever raop tries to connect to the IPV6 host, it crashes, and this happens frequently e.g. when I stop streaming. This ugly fix removes the IPV6 host and lets me stream audio flawlessly with IPV4 :).
