### PR TITLE
Return NULL if IPV6 since we do not support it (yet)

### DIFF
--- a/src/modules/raop/raop_client.c
+++ b/src/modules/raop/raop_client.c
@@ -1155,7 +1155,7 @@ int pa_raop_client_flush(pa_raop_client *c) {
 
     pa_assert(c);
 
-    if (c->rtsp != NULL) {
+	if (c->rtsp != NULL && pa_rtsp_exec_ready(c->rtsp)) {
         rv = pa_rtsp_flush(c->rtsp, c->seq, c->rtptime);
         c->udp_sync_count = 0;
     }

--- a/src/modules/raop/raop_client.c
+++ b/src/modules/raop/raop_client.c
@@ -1155,7 +1155,7 @@ int pa_raop_client_flush(pa_raop_client *c) {
 
     pa_assert(c);
 
-	if (c->rtsp != NULL && pa_rtsp_exec_ready(c->rtsp)) {
+    if (c->rtsp != NULL && pa_rtsp_exec_ready(c->rtsp)) {
         rv = pa_rtsp_flush(c->rtsp, c->seq, c->rtptime);
         c->udp_sync_count = 0;
     }

--- a/src/modules/raop/raop_client.c
+++ b/src/modules/raop/raop_client.c
@@ -1051,6 +1051,14 @@ pa_raop_client* pa_raop_client_new(pa_core *core, const char *host,
 
     if (pa_parse_address(host, &a) < 0 || a.type == PA_PARSED_ADDRESS_UNIX)
         return NULL;
+        
+    if(strstr(host,"::"))
+    {
+        pa_log_warn("Host: %s",host);
+        pa_log_warn("IPV6 is not supported!");
+        return NULL;
+    }
+
 
     c->core = core;
     c->tcp_fd = -1;

--- a/src/modules/raop/raop_client.c
+++ b/src/modules/raop/raop_client.c
@@ -1044,7 +1044,7 @@ pa_raop_client* pa_raop_client_new(pa_core *core, const char *host,
                                    pa_raop_protocol_t protocol,
                                    pa_sample_spec spec) {
     pa_parsed_address a;
-    pa_raop_client *c = pa_xnew0(pa_raop_client, 1);
+    pa_raop_client* c;
 
     pa_assert(core);
     pa_assert(host);
@@ -1052,13 +1052,13 @@ pa_raop_client* pa_raop_client_new(pa_core *core, const char *host,
     if (pa_parse_address(host, &a) < 0 || a.type == PA_PARSED_ADDRESS_UNIX)
         return NULL;
         
-    if(strstr(host,"::"))
+    if(a.type == PA_PARSED_ADDRESS_TCP6)
     {
         pa_log_warn("Host: %s",host);
         pa_log_warn("IPV6 is not supported!");
         return NULL;
     }
-
+    c = pa_xnew0(pa_raop_client, 1);
 
     c->core = core;
     c->tcp_fd = -1;


### PR DESCRIPTION
I get dual shairport hosts. One is IPV4 and the other one is IPV6. Whenever raop tries to connect to the IPV6 host, it crashes, and this happens frequently e.g. when I stop streaming. This fix removes the IPV6 host and lets me stream audio flawlessly with IPV4 :).
