### PR TITLE
Proposal to fix issue 36 and 37

### DIFF
--- a/src/modules/raop/raop-client.c
+++ b/src/modules/raop/raop-client.c
@@ -88,6 +88,7 @@
 #define VOLUME_MIN -144.0
 
 #define UDP_DEFAULT_PKT_BUF_SIZE 1000
+#define APPLE_CHALLENGE_LENGTH 16
 
 struct pa_raop_client {
     pa_core *core;
@@ -1192,7 +1193,7 @@ static void rtsp_auth_cb(pa_rtsp_client *rtsp, pa_rtsp_state_t state, pa_rtsp_st
     switch (state) {
         case STATE_CONNECT: {
             char *sci = NULL, *sac = NULL;
-            uint16_t rac;
+            uint8_t rac[APPLE_CHALLENGE_LENGTH];
             struct {
                 uint32_t ci1;
                 uint32_t ci2;
@@ -1203,9 +1204,9 @@ static void rtsp_auth_cb(pa_rtsp_client *rtsp, pa_rtsp_state_t state, pa_rtsp_st
             sci = pa_sprintf_malloc("%08x%08x",rci.ci1, rci.ci2);
             pa_rtsp_add_header(c->rtsp, "Client-Instance", sci);
 
-            pa_random(&rac, sizeof(rac));
+            pa_random(&rac, APPLE_CHALLENGE_LENGTH);
             /* Generate a random Apple-Challenge key */
-            pa_raop_base64_encode(&rac, 8 * sizeof(rac), &sac);
+            pa_raop_base64_encode(&rac, APPLE_CHALLENGE_LENGTH, &sac);
             rtrim_char(sac, '=');
             pa_rtsp_add_header(c->rtsp, "Apple-Challenge", sac);
 

--- a/src/modules/rtp/rtsp_client.c
+++ b/src/modules/rtp/rtsp_client.c
@@ -238,7 +238,6 @@ static void line_callback(pa_ioline *line, const char *s, void *userdata) {
 
         pa_log_debug("Full response received. Dispatching");
         headers_read(c);
-        c->waiting = 1;
         goto exit;
     }
 
@@ -483,7 +482,8 @@ static int rtsp_exec(pa_rtsp_client *c, const char *cmd,
     pa_log_debug(hdrs);*/
     pa_ioline_puts(c->ioline, hdrs);
     pa_xfree(hdrs);
-
+    /* The command is sent we can configure the rtsp client structure to handle a new answer */
+    c->waiting = 1;
     return 0;
 }
 


### PR DESCRIPTION
issue 37 : Allocation for Apple-Challenge key is now defined to 16 bytes (instead of 16 bits)

issue 36 : The line_callback function in rstp_client.c does not access anymmore to the pa_rtsp_client structure after sending the header to the RAOP side. The restart of the line_callback thanks to the set of c->waiting variable is done after each RTSP send command in rtsp_exec function.
